### PR TITLE
update Makefile

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,6 +3,7 @@ include ../build.mk
 
 all:
 	$(CC) -o ./benchmark \
+		-lstdc++  \
 		$(CFLAGS) \
 		-I../src \
 		../src/util/*.o benchmark.cpp \


### PR DESCRIPTION
prevent 'undefined reference to `__gxx_personality_v0''  error while compiling  on  CentOS release 6.4 (Final)