### PR TITLE
增加SSE推送方式的协议支持，增加/sse订阅url，增加sse.html作为SSE推送的例子

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ icomet-server
 icomet-server-*
 online-server
 dev_icomet.conf
+patch
 *.dSYM
 *.pid
 *.o
@@ -21,6 +22,7 @@ tools/benchmark
 *.pyc
 *.swp
 *.exe
+*.patch
 icomet
 config.mk
 deps/libevent-2.0.21-stable/test

--- a/demo/web/sse.html
+++ b/demo/web/sse.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+    </head>
+    <body>
+        <script>
+            var source = new EventSource("http://127.0.0.1:8100/sse?cname=12&seq=1");
+            source.onmessage = function(e) {
+                document.body.innerHTML += e.data + '<br>';
+            };
+        </script>
+        <pre>
+            Event Source Listen on "http://127.0.0.1:8100/sse?cname=12&seq=1"
+            Publish Message :
+                curl -v "http://127.0.0.1:8000/push?cname=12&content=HelloSSE"
+        </pre>
+    </body>
+</html>

--- a/src/comet/icomet-server.cpp
+++ b/src/comet/icomet-server.cpp
@@ -103,6 +103,10 @@ void stream_handler(struct evhttp_request *req, void *arg){
 	serv->stream(req);
 }
 
+void sse_handler(struct evhttp_request *req, void *arg){
+	serv->sse(req);
+}
+
 void ping_handler(struct evhttp_request *req, void *arg){
 	serv->ping(req);
 }
@@ -285,6 +289,8 @@ int main(int argc, char **argv){
 		evhttp_set_cb(front_http, "/iframe", iframe_handler, NULL);
 		// http endless chunk
 		evhttp_set_cb(front_http, "/stream", stream_handler, NULL);
+		// http5 Server Send Event
+		evhttp_set_cb(front_http, "/sse", sse_handler, NULL);
 		// /ping?cb=jsonp
 		evhttp_set_cb(front_http, "/ping", ping_handler, NULL);
 

--- a/src/comet/server.cpp
+++ b/src/comet/server.cpp
@@ -215,6 +215,10 @@ int Server::stream(struct evhttp_request *req){
 	return this->sub(req, Subscriber::STREAM);
 }
 
+int Server::sse(struct evhttp_request *req){
+	return this->sub(req, Subscriber::SSE);
+}
+
 int Server::sub_end(Subscriber *sub){
 	subscribers --;
 	Channel *channel = sub->channel;

--- a/src/comet/server.h
+++ b/src/comet/server.h
@@ -58,6 +58,7 @@ public:
 	int poll(struct evhttp_request *req);
 	int iframe(struct evhttp_request *req);
 	int stream(struct evhttp_request *req);
+	int sse(struct evhttp_request *req);
 
 	int pub(struct evhttp_request *req, bool encoded);
 	int broadcast(struct evhttp_request *req);

--- a/src/comet/subscriber.h
+++ b/src/comet/subscriber.h
@@ -19,7 +19,8 @@ public:
 	enum Type{
 		POLL	= 0,
 		STREAM	= 1,
-		IFRAME	= 2
+		IFRAME	= 2,
+		SSE		= 3
 	};
 public:
 	Subscriber();


### PR DESCRIPTION
`/stream`的订阅方式，返回的内容格式不支持SSE，导致HTML5端无法使用EventSource JS对象。
修改的代码版本，增加了SSE要求的返回头，修改了body的内容chunk格式，增加了`/sse`URL用于订阅SSE消息，使用方法和`/stream`一致。